### PR TITLE
Configure Postgres utility binaries path in PgAdmin

### DIFF
--- a/pgadmin/apt.yml
+++ b/pgadmin/apt.yml
@@ -1,3 +1,4 @@
 ---
 packages:
   - libpq-dev
+  - postgresql-client

--- a/pgadmin/config_local.py
+++ b/pgadmin/config_local.py
@@ -25,3 +25,15 @@ SESSION_DB_PATH = os.path.join(DATA_DIR, 'sessions')
 # for application logs, so pgadmin must
 # log to there if we want to see them
 LOG_FILE="/home/vcap/app/pgadmin4.log"
+
+
+# PgAdmin expects to be able to find a
+# couple of standard Postgres binaries.
+# They live outside of the normal path
+# for Ubuntu, so we have to set them.
+DEFAULT_BINARY_PATHS= {
+    "pg": "/home/vcap/deps/0/bin/",
+    # These are left blank deliberately
+    "ppas": "",
+    "gpdb": ""
+}


### PR DESCRIPTION
What
---
PgAdmin needs access to the normal set of Postgresql utility binaries (e.g
pgdump, psql), and the path to them is normally defined in `config_distro.py`.
However, when installing them via the Apt build pack, they end up in
`/home/vcap/dep/{x}/bin/`, and so we need to set that path explicitly in
`config_local.py`.

How to review
---
1. Code review
1. Deploy and [check that the binary paths are set in PgAdmin](https://www.pgadmin.org/docs/pgadmin4/development/preferences.html#the-paths-node)

Who can review
---
Anyone