### PR TITLE
[WIP] Run Prometheus and Grafana on PaaS

### DIFF
--- a/prometheus-and-grafana/demo/backend/Gemfile
+++ b/prometheus-and-grafana/demo/backend/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "httparty"
+gem "redis"
+gem "prometheus-client"

--- a/prometheus-and-grafana/demo/backend/Gemfile.lock
+++ b/prometheus-and-grafana/demo/backend/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
+    multi_xml (0.6.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    prometheus-client (2.1.0)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    redis (4.2.2)
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty
+  prometheus-client
+  redis
+  sinatra
+
+BUNDLED WITH
+   2.0.2

--- a/prometheus-and-grafana/demo/backend/main.rb
+++ b/prometheus-and-grafana/demo/backend/main.rb
@@ -1,0 +1,36 @@
+require "json"
+require "redis"
+require "sinatra"
+require "httparty"
+require 'prometheus/client'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
+VCAP_SERVICES = JSON.parse(ENV["VCAP_SERVICES"])
+REDIS_CREDENTIALS = VCAP_SERVICES["redis"][0]["credentials"]
+REDIS = Redis.new(:url => REDIS_CREDENTIALS["uri"])
+
+prometheus = Prometheus::Client.registry
+submissions_received = prometheus.counter(:submissions_received, docstring: 'how many submissions the app has received')
+submissions_queued = prometheus.counter(:submissions_forwarded, docstring: 'how many submissions the app successfully put on the queue')
+submissions_errored = prometheus.counter(:submissions_errored, docstring: 'how many submissions the app errored and was unable to enqueue')
+
+get "/" do
+   "Hello world"
+end
+
+post "/submissions" do
+  submissions_received.increment
+  begin
+    REDIS.rpush("submissions", {message: params[:message]}.to_json)
+    submissions_queued.increment
+    "Success"
+  rescue Exception => e
+    submissions_errored.increment
+    puts e.inspect
+    e.message
+  end
+end

--- a/prometheus-and-grafana/demo/backend/manifest.yml
+++ b/prometheus-and-grafana/demo/backend/manifest.yml
@@ -1,0 +1,15 @@
+---
+applications:
+  - name: observe-demo-backend
+    random-route: true
+    buildpacks:
+      - ruby_buildpack
+    services:
+      - observe-demo-db
+    disk_quota: 128M
+    memory: 256M
+    processes:
+      - type: web
+        health-check-type: http
+        health-check-http-endpoint: /
+        command: ruby main.rb

--- a/prometheus-and-grafana/demo/frontend/Gemfile
+++ b/prometheus-and-grafana/demo/frontend/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "httparty"
+gem "prometheus-client"

--- a/prometheus-and-grafana/demo/frontend/Gemfile.lock
+++ b/prometheus-and-grafana/demo/frontend/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
+    multi_xml (0.6.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    prometheus-client (2.1.0)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty
+  prometheus-client
+  sinatra
+
+BUNDLED WITH
+   2.0.2

--- a/prometheus-and-grafana/demo/frontend/main.rb
+++ b/prometheus-and-grafana/demo/frontend/main.rb
@@ -1,0 +1,33 @@
+require "sinatra"
+require "httparty"
+require 'prometheus/client'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
+BACKEND_URL = ENV["BACKEND_URL"]
+BACKEND_SUBMISSIONS_URL = "#{BACKEND_URL}/submissions"
+
+prometheus = Prometheus::Client.registry
+submissions_received = prometheus.counter(:submissions_received, docstring: 'how many submissions the app has received')
+submissions_forwarded = prometheus.counter(:submissions_forwarded, docstring: 'how many submissions the app successfully forwarded')
+submissions_errored = prometheus.counter(:submissions_errored, docstring: 'how many submissions the app errored and was unable to forward')
+
+get "/" do
+   "Hello world"
+end
+
+post "/submit" do
+    submissions_received.increment
+    begin
+        resp = HTTParty.post(BACKEND_SUBMISSIONS_URL, body: {message: params['message']})
+        throw "Unexpected response code from backend: #{resp.code}" if resp.code != 200
+        submissions_forwarded.increment
+        "Success: #{resp.body}"
+    rescue Exception => e
+        submissions_errored.increment
+        "Failure: #{e.message}"
+    end
+end

--- a/prometheus-and-grafana/demo/frontend/manifest.yml
+++ b/prometheus-and-grafana/demo/frontend/manifest.yml
@@ -1,0 +1,15 @@
+---
+applications:
+  - name: observe-demo-frontend
+    random-route: true
+    buildpacks:
+      - ruby_buildpack
+    env:
+      BACKEND_URL: http://observe-demo-backend.apps.internal:8080
+    disk_quota: 128M
+    memory: 64M
+    processes:
+      - type: web
+        health-check-type: http
+        health-check-http-endpoint: /
+        command: ruby main.rb

--- a/prometheus-and-grafana/demo/notes.md
+++ b/prometheus-and-grafana/demo/notes.md
@@ -1,0 +1,1 @@
+cf map-route APP_NAME apps.internal --hostname APP_NAME

--- a/prometheus-and-grafana/demo/visitor-simulator/manifest.yml
+++ b/prometheus-and-grafana/demo/visitor-simulator/manifest.yml
@@ -1,0 +1,14 @@
+---
+applications:
+  - name: observe-demo-simulated-visitors
+    no-route: true
+    buildpacks:
+      - binary_buildpack
+    env:
+      FRONTEND_DOMAIN: observe-demo-frontend-appreciative-duiker-eh.london.cloudapps.digital
+    disk_quota: 128M
+    memory: 32M
+    type: worker
+    command: ./run.sh
+    health-check-type: process
+    instances: 3

--- a/prometheus-and-grafana/demo/visitor-simulator/run.sh
+++ b/prometheus-and-grafana/demo/visitor-simulator/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+while true; do
+    curl \
+        -X POST \
+        "https://${FRONTEND_DOMAIN}/submit" \
+        -d message="Hi from simulated visitor at $(date)"
+done

--- a/prometheus-and-grafana/demo/worker/Gemfile
+++ b/prometheus-and-grafana/demo/worker/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "httparty"
+gem "redis"
+gem 'prometheus_exporter'

--- a/prometheus-and-grafana/demo/worker/Gemfile.lock
+++ b/prometheus-and-grafana/demo/worker/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
+    multi_xml (0.6.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    prometheus_exporter (0.5.3)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    redis (4.2.2)
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty
+  prometheus_exporter
+  redis
+  sinatra
+
+BUNDLED WITH
+   2.0.2

--- a/prometheus-and-grafana/demo/worker/app_autoscaler_policy.json
+++ b/prometheus-and-grafana/demo/worker/app_autoscaler_policy.json
@@ -1,0 +1,22 @@
+{
+  "instance_min_count": 1,
+  "instance_max_count": 11,
+  "scaling_rules": [
+    {
+      "metric_type": "submissions_in_queue",
+      "threshold": 200,
+      "operator": ">",
+      "adjustment": "+1",
+      "breach_duration_secs": 60,
+      "cool_down_secs": 60
+    },
+    {
+      "metric_type": "submissions_in_queue",
+      "threshold": 1,
+      "operator": "<",
+      "adjustment": "-1",
+      "breach_duration_secs": 120,
+      "cool_down_secs": 180
+    }
+  ]
+}

--- a/prometheus-and-grafana/demo/worker/main.rb
+++ b/prometheus-and-grafana/demo/worker/main.rb
@@ -1,0 +1,66 @@
+require "json"
+require "redis"
+require "httparty"
+require 'prometheus_exporter'
+require 'prometheus_exporter/server'
+# client allows instrumentation to send info to server
+require 'prometheus_exporter/client'
+require 'prometheus_exporter/instrumentation'
+
+server = PrometheusExporter::Server::WebServer.new bind: '0.0.0.0', port: 8080
+server.start
+PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
+PrometheusExporter::Instrumentation::Process.start(type: "worker")
+
+VCAP_APPLICATION = JSON.parse(ENV["VCAP_APPLICATION"])
+APPLICATION_GUID = VCAP_APPLICATION["application_id"]
+VCAP_SERVICES = JSON.parse(ENV["VCAP_SERVICES"])
+REDIS_CREDENTIALS = VCAP_SERVICES["redis"][0]["credentials"]
+REDIS = Redis.new(:url => REDIS_CREDENTIALS["uri"])
+AUTOSCALER_CREDENTIALS = VCAP_SERVICES["autoscaler"][0]["credentials"]
+AUTOSCALER_URL = AUTOSCALER_CREDENTIALS["custom_metrics"]["url"]
+AUTOSCALER_USERNAME = AUTOSCALER_CREDENTIALS["custom_metrics"]["username"]
+AUTOSCALER_PASSWORD = AUTOSCALER_CREDENTIALS["custom_metrics"]["password"]
+AUTOSCALER_CUSTOM_METRIC_SUBMISSION_URL = "#{AUTOSCALER_URL}/v1/apps/#{APPLICATION_GUID}/metrics"
+
+submissions_processed = PrometheusExporter::Metric::Counter.new("submissions_processed", "how many submissions the worker has processed from Redis")
+submissions_in_queue = PrometheusExporter::Metric::Gauge.new("submissions_in_queue", "how many submissions are waiting in Redis")
+server.collector.register_metric(submissions_processed)
+server.collector.register_metric(submissions_in_queue)
+
+i = -1
+loop do
+  i += 1
+
+  if i % 1000 == 0
+    number_of_submissions_in_queue = REDIS.llen("submissions")
+    submissions_in_queue.observe(number_of_submissions_in_queue)
+
+    begin
+      resp = HTTParty.post(AUTOSCALER_CUSTOM_METRIC_SUBMISSION_URL, body: {
+        instance_index: ENV["CF_INSTANCE_INDEX"].to_i,
+        metrics: [{
+          name: "submissions_in_queue",
+          value: number_of_submissions_in_queue.to_s.to_i
+        }]
+      }.to_json, :basic_auth => {username: AUTOSCALER_USERNAME, password: AUTOSCALER_PASSWORD})
+      throw "Unexpected response code from backend #{resp.code} with body: '#{resp.body}'" if resp.code != 200
+      puts "Filed scheduled metrics: #{number_of_submissions_in_queue} submissions in queue"
+    rescue Exception => e
+      puts "Error submitting custom metric 'submissions_in_queue' to the autoscaler: #{e.message}"
+    end
+  end
+
+  begin
+    item = REDIS.lpop("submissions")
+  rescue Exception => e
+    puts "Error: #{e.message}"
+    STDOUT.flush
+    next
+  end
+
+  unless item.nil?
+    submissions_processed.observe(1)
+    sleep 0.1
+  end
+end

--- a/prometheus-and-grafana/demo/worker/manifest.yml
+++ b/prometheus-and-grafana/demo/worker/manifest.yml
@@ -1,0 +1,15 @@
+---
+applications:
+  - name: observe-demo-worker
+    random-route: true
+    buildpacks:
+      - ruby_buildpack
+    services:
+      - autoscaler
+      - observe-demo-db
+    disk_quota: 128M
+    memory: 72M
+    type: web
+    health-check-type: http
+    health-check-http-endpoint: /metrics
+    command: ruby main.rb

--- a/prometheus-and-grafana/grafana/README.md
+++ b/prometheus-and-grafana/grafana/README.md
@@ -1,0 +1,13 @@
+
+You may be better off trying https://github.com/SpringerPE/cf-grafana-buildpack.
+
+Basic instructions for GOV.UK PaaS:
+
+```
+$ cf create-service postgres small-ha-11 grafana-db
+[ wait until service create succeeded - see `cf service grafana-db` ]
+
+$ cf push -f manifest.yml
+```
+
+Manually add Prometheus as a Data Source using Grafana's web UI.

--- a/prometheus-and-grafana/grafana/manifest.yml
+++ b/prometheus-and-grafana/grafana/manifest.yml
@@ -1,0 +1,19 @@
+---
+applications:
+  - name: grafana
+    random-route: true
+    buildpacks:
+      - binary_buildpack
+    services:
+      - grafana-db
+    env:
+      GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: true
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ((admin_password))
+    disk_quota: 256M
+    memory: 256M
+    processes:
+      - type: web
+        health-check-type: http
+        health-check-http-endpoint: /
+        command: ./run.sh

--- a/prometheus-and-grafana/grafana/run.sh
+++ b/prometheus-and-grafana/grafana/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Go get Grafana
+wget https://dl.grafana.com/oss/release/grafana-7.2.0.linux-amd64.tar.gz
+tar -zxvf grafana-7.2.0.linux-amd64.tar.gz
+
+# Go get YQ
+wget -q https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64
+YQ="./yq_linux_amd64"
+chmod +x $YQ
+
+# All options in the configuration file can be overridden using environment variables using the syntax:
+# GF_<SectionName>_<KeyName>
+# Where the section name is the text within the brackets. Everything should be uppercase, . and - should be replaced by _.
+# https://grafana.com/docs/grafana/latest/administration/configuration/?plcmt=footer
+export GF_SERVER_HTTP_PORT="${PORT}"
+export GF_DATABASE_TYPE=postgres
+export GF_DATABASE_URL=$(echo "${VCAP_SERVICES}" | $YQ read - "postgres[0].credentials.uri")
+export GF_DATABASE_SSL_MODE=require
+
+cd grafana-7.2.0
+./bin/grafana-server

--- a/prometheus-and-grafana/paas-prometheus-exporter/manifest.yml
+++ b/prometheus-and-grafana/paas-prometheus-exporter/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: paas-prometheus-exporter
+  memory: 60M
+  instances: 1
+  buildpacks:
+    - go_buildpack
+  stack: cflinuxfs3
+  env:
+    GOPACKAGENAME: github.com/alphagov/paas-prometheus-exporter

--- a/prometheus-and-grafana/paas-prometheus-exporter/paas-prometheus-exporter-readme.md
+++ b/prometheus-and-grafana/paas-prometheus-exporter/paas-prometheus-exporter-readme.md
@@ -1,0 +1,7 @@
+```
+cf push --no-start paas-prometheus-exporter --random-route
+cf set-env paas-prometheus-exporter API_ENDPOINT https://api.london.cloud.service.gov.uk
+cf set-env paas-prometheus-exporter USERNAME miki.mokrysz+prometheus-endpoint-testing@digital.cabinet-office.gov.uk
+cf set-env paas-prometheus-exporter PASSWORD ",JYZrE[eFo786wW/z8At"
+cf start paas-prometheus-exporter
+```

--- a/prometheus-and-grafana/prometheus/manifest.yml
+++ b/prometheus-and-grafana/prometheus/manifest.yml
@@ -1,0 +1,18 @@
+---
+applications:
+  - name: prometheus
+    random-route: true
+    buildpacks:
+      - binary_buildpack
+    services:
+      - prometheus-db
+    disk_quota: 4G
+    memory: 4G
+    env:
+      PAAS_READONLY_USERNAME: miki.mokrysz+prometheus-endpoint-testing@digital.cabinet-office.gov.uk
+      PAAS_READONLY_PASSWORD: ",JYZrE[eFo786wW/z8At"
+    processes:
+      - type: web
+        health-check-type: http
+        health-check-http-endpoint: /-/ready
+        command: ./run.sh

--- a/prometheus-and-grafana/prometheus/prometheus-config.template.yml
+++ b/prometheus-and-grafana/prometheus/prometheus-config.template.yml
@@ -1,0 +1,59 @@
+scrape_configs:
+- job_name: prometheus
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - localhost:8080
+
+- job_name: govuk_paas_redis
+  scheme: https
+  basic_auth:
+    username: ((paas_readonly_username))
+    password: ((paas_readonly_password))
+  static_configs:
+  - targets:
+    - redis.metrics.london.cloud.service.gov.uk
+  metrics_path: /metrics
+  scrape_interval: 300s
+  scrape_timeout: 120s
+  honor_timestamps: true
+  metric_relabel_configs:
+  # Prepend `paas_redis_` so the metrics are easier to find
+  - action: replace
+    source_labels: [__name__]
+    target_label: __name__
+    regex: (.*)
+    replacement: paas_redis_${1}
+
+- job_name: paas_prometheus_exporter
+  scheme: https
+  static_configs:
+  - targets:
+    - paas-prometheus-exporter-smart-toucan-jg.london.cloudapps.digital
+  metrics_path: /metrics
+  metric_relabel_configs:
+  # Prepend `paas_` so the metrics are easier to find
+  - action: replace
+    source_labels: [__name__]
+    target_label: __name__
+    regex: (.*)
+    replacement: paas_${1}
+
+- job_name: app_custom_metrics
+  scheme: http
+  dns_sd_configs:
+  - names:
+      - observe-demo-frontend.apps.internal
+      - observe-demo-backend.apps.internal
+      - observe-demo-worker.apps.internal
+    port: 8080
+    type: A
+  relabel_configs:
+  - action: replace
+    source_labels: [__meta_dns_name]
+    target_label: host
+    replacement: ${1}

--- a/prometheus-and-grafana/prometheus/run.sh
+++ b/prometheus-and-grafana/prometheus/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Go get Prometheus
+wget -q https://github.com/prometheus/prometheus/releases/download/v2.16.0/prometheus-2.16.0.linux-amd64.tar.gz
+tar xzf prometheus-2.16.0.linux-amd64.tar.gz
+chmod +x ./prometheus-2.16.0.linux-amd64/prometheus
+
+# Go get YQ
+wget -q https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64
+YQ="./yq_linux_amd64"
+chmod +x $YQ
+
+echo "${VCAP_SERVICES}" \
+  | $YQ -P read - "influxdb[0].credentials.prometheus" \
+  > /home/vcap/app/influx-prometheus-config.yml
+
+# Interpolate the variables in to the config file
+cat /home/vcap/app/prometheus-config.template.yml \
+  | $YQ write - "scrape_configs.(job_name == govuk_paas_redis).basic_auth.username" "${PAAS_READONLY_USERNAME}" \
+  | $YQ write - "scrape_configs.(job_name == govuk_paas_redis).basic_auth.password" "${PAAS_READONLY_PASSWORD}" \
+  > /home/vcap/app/authed-prometheus-config.yml
+
+$YQ -P merge \
+  /home/vcap/app/influx-prometheus-config.yml \
+  /home/vcap/app/authed-prometheus-config.yml \
+  > /home/vcap/app/prometheus-config.yml
+
+cat /home/vcap/app/prometheus-config.yml
+
+# Run Promtheus with the config file
+./prometheus-2.16.0.linux-amd64/prometheus \
+  --config.file=prometheus-config.yml \
+  --web.listen-address="0.0.0.0:${PORT}"


### PR DESCRIPTION
## What

This PR includes Prometheus and Grafana configured to run on PaaS. Prometheus gets persistent storage via a PaaS InfluxDB. Grafana gets persistent storage via a PaaS Postgres.

Both projects are configured in an extremely improvised manner. This can be further improved using third-party projects such as [Springer's Grafana buildpack](https://github.com/SpringerPE/cf-grafana-buildpack) or [DfE's PaaS-Prometheus-via-Terraform](https://github.com/DFE-Digital/bat-platform-building-blocks/tree/ebf85af11571fb1ce556f738e90e16a356092d4c/terraform/modules/prometheus).

This commit also includes a fictional government service that the Prometheus/Grafana are setup to monitor. This PR can be further improved by including the monitoring dashboards.

Cost estimate from the Calculator was about £150/month, but that included the whole demo service as well. We'll need to figure out what production plan sizes should be, and approach to HA/reliability, before having a final price.

## How to review

This could be merged. I'd rather get it a bit more usable first. This was my recent firebreak project.

If you work on PaaS and want to study this deployed, look in London's `govuk-paas` org in the `46bit` space.

## Further work

**This PR**
* [ ] Look into switching from my hacky Grafana configuration to the Grafana Buildpack
* [ ] Include the monitoring dashboards for the demo service
* [ ] Improve the monitoring dashboards using response time visualisations/etc from Digital Marketplace
* [ ] Set up using Terraform rather than by hand
* [ ] Put an auth route service in front of the Prometheus, as it's wide-open to the world right now
* [ ] Add a README

**Before making this a fully-endorsed approach to monitoring services on PaaS**
* [ ] Try to understand the risks of having two Prometheuses running against the same data in InfluxDB for a short time when we roll cells
* [ ] Come up with recommendations around HA, or work around the need for it
* [ ] See whether Elastic will replace the need for this
* [ ] Suggest an approach for tenant alerting (Grafana alerts? via what?)

**Eventually**
* [ ] Brokerise this, like RE Observe did within GDS?
* [ ] Get logs in too (e.g., via Loki)?